### PR TITLE
Make alarm tests deterministic and verify real device delivery

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,25 @@ on:
   push:
     branches: [main, master, develop]
   pull_request:
-    branches: [main, master, develop]
+    branches: [main, master, develop, "codex/**"]
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: testing-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     name: Build & Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      TZ: UTC
 
     steps:
       - name: Checkout
@@ -27,14 +40,17 @@ jobs:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       # Runs commonTest + androidHostTest for core module
-      - name: Run Core Module Tests
-        run: ./gradlew :core:testAndroidHostTest
+      - name: Run host suites
+        run: ./gradlew :core:testAndroidHostTest :shared:testAndroidHostTest :androidApp:testDebugUnitTest --continue
 
-      - name: Run Shared Module Tests
-        run: ./gradlew :shared:testAndroidHostTest
-
-      - name: Run Android App Tests
-        run: ./gradlew :androidApp:testDebugUnitTest
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: host-test-reports
+          path: |
+            **/build/reports/tests/**
+            **/build/test-results/**
 
       - name: Build Debug APK
         run: ./gradlew :androidApp:assembleDebug
@@ -45,3 +61,65 @@ jobs:
           name: debug-apk
           path: androidApp/build/outputs/apk/debug/*.apk
           retention-days: 7
+
+  device:
+    name: Alarm delivery API ${{ matrix.api }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        api: ${{ fromJSON((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '[30, 32, 35, 36]' || '[35]') }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Build app and test APKs
+        run: ./gradlew :androidApp:assembleDebug :androidApp:assembleDebugAndroidTest
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - uses: reactivecircus/android-emulator-runner@v2
+        env:
+          EXTENDED: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+        with:
+          api-level: ${{ matrix.api }}
+          arch: x86_64
+          target: google_apis
+          disable-animations: true
+          script: bash scripts/ci_alarm_delivery.sh
+      - name: Upload device evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: alarm-delivery-api-${{ matrix.api }}
+          path: build/alarm-device-results/
+
+  ios:
+    name: iOS simulator tests
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-15
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v4
+      - uses: android-actions/setup-android@v4
+      - name: Run native shared and platform tests
+        run: ./gradlew :core:iosSimulatorArm64Test :shared:iosSimulatorArm64Test --continue
+      - name: Upload native reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-test-reports
+          path: |
+            **/build/reports/tests/**
+            **/build/test-results/**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,10 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
-      # Runs commonTest + androidHostTest for core module
+      - name: Check device runner cleanup
+        run: python3 -B -m unittest discover -s scripts -p '*_test.py'
+
+      # Runs common and Android host tests across all modules
       - name: Run host suites
         run: ./gradlew :core:testAndroidHostTest :shared:testAndroidHostTest :androidApp:testDebugUnitTest --continue
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The project follows **Clean Architecture** with the **MVVM** pattern:
 * [Lyricist](https://github.com/adrielcafe/lyricist) - Type-safe string localization for Compose
 
 ### Testing
+
+See [the testing guide](docs/testing.md) for host suites, real-device lifecycle checks, CI, and physical-device release validation.
 * [Kotlin Test](https://kotlinlang.org/api/latest/kotlin.test/) - Multiplatform testing
 * [Turbine](https://github.com/cashapp/turbine) - Flow testing
 * [Kotest](https://kotest.io/) - Assertions library

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -58,7 +58,7 @@ android {
     }
 
     testOptions {
-        unitTests.isReturnDefaultValues = true
+        unitTests.isReturnDefaultValues = false
         unitTests.isIncludeAndroidResources = true
     }
 }

--- a/androidApp/src/androidTest/kotlin/com/timilehinaregbesola/mathalarm/AlarmDeliverySeedTest.kt
+++ b/androidApp/src/androidTest/kotlin/com/timilehinaregbesola/mathalarm/AlarmDeliverySeedTest.kt
@@ -1,31 +1,60 @@
 package com.timilehinaregbesola.mathalarm
 
+import android.app.AlarmManager
+import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
 import com.timilehinaregbesola.mathalarm.domain.model.Alarm
 import com.timilehinaregbesola.mathalarm.framework.Usecases
 import com.timilehinaregbesola.mathalarm.interactors.AlarmInteractor
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Assume.assumeTrue
 import org.junit.Test
-import org.junit.Assert.assertNotNull
 import org.koin.core.context.GlobalContext
 
-/** Seeds a real alarm, then exits so adb can kill the process and put the emulator in Doze.
- * Run only on a disposable debug emulator; see the review's validation instructions.
- */
+/** External runner owns process death/reboot and observes delivery before restarting instrumentation. */
 class AlarmDeliverySeedTest {
+    private val arguments get() = InstrumentationRegistry.getArguments()
+    private fun context(): Context {
+        assumeTrue("Run through scripts/test_alarm_delivery.py", arguments.getString("alarmLifecycle") == "true")
+        return InstrumentationRegistry.getInstrumentation().targetContext.also {
+            check(it.packageName.endsWith(".debug"))
+        }
+    }
+
     @Test fun seedColdStartAlarm() = runBlocking {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
-        check(context.packageName.endsWith(".debug"))
-        val trigger = System.currentTimeMillis() + 45_000
+        val context = context()
+        val delaySeconds = arguments.getString("delaySeconds", "45").toLong()
+        require(delaySeconds in 15..600)
+        val trigger = System.currentTimeMillis() + delaySeconds * 1000
         val usecases = GlobalContext.get().get<Usecases>()
         usecases.command {
-            val alarm = Alarm(alarmId = 900001, hour = 7, minute = 0, isOn = true, isSaved = true,
-                alarmTone = "content://missing/reliability-tone", title = "Reliability test",
+            findAlarm(TEST_ID)?.let { deleteAlarm(it) }
+            context.getSharedPreferences("alarm_delivery_log", Context.MODE_PRIVATE).edit().clear().commit()
+            val alarm = Alarm(alarmId = TEST_ID, hour = 7, minute = 0, isOn = true, isSaved = true,
+                alarmTone = "content://missing/reliability-tone", title = "Reliability test", snooze = 1,
                 scheduleInitialized = true, pendingTimes = listOf(trigger))
             addAlarm(alarm)
             GlobalContext.get().get<AlarmInteractor>().schedule(alarm, trigger)
         }
-        val manager = context.getSystemService(android.content.Context.ALARM_SERVICE) as android.app.AlarmManager
-        assertNotNull(manager.nextAlarmClock)
+        val manager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        assertEquals("The OS must register this occurrence", trigger, manager.nextAlarmClock?.triggerTime)
     }
+
+    @Test fun verifyCompleted() = runBlocking {
+        context()
+        val stored = GlobalContext.get().get<Usecases>().findAlarm(TEST_ID)!!
+        assertFalse(stored.isOn)
+        assertNull(stored.activeAt)
+        assertNull(stored.snoozedUntil)
+        assertTrue(stored.pendingTimes.isEmpty())
+    }
+
+    @Test fun cleanup(): Unit = runBlocking {
+        context()
+        val usecases = GlobalContext.get().get<Usecases>()
+        usecases.command { findAlarm(TEST_ID)?.let { deleteAlarm(it) } }
+    }
+
+    companion object { const val TEST_ID = 900001L }
 }

--- a/androidApp/src/test/java/com/timilehinaregbesola/mathalarm/AlarmSystemIntegrationTest.kt
+++ b/androidApp/src/test/java/com/timilehinaregbesola/mathalarm/AlarmSystemIntegrationTest.kt
@@ -11,7 +11,11 @@ import com.timilehinaregbesola.mathalarm.domain.model.Alarm
 import com.timilehinaregbesola.mathalarm.fake.DateTimeProviderFake
 import com.timilehinaregbesola.mathalarm.framework.Usecases
 import com.timilehinaregbesola.mathalarm.provider.DateTimeProvider
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.toInstant
 import kotlinx.datetime.LocalDateTime
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -32,7 +36,9 @@ import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R], application = TestApplication::class)
-class AlarmSystemEndToEndTest {
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class AlarmSystemIntegrationTest {
+    private val testScheduler: TestCoroutineScheduler get() = GlobalContext.get().get()
 
     private lateinit var usecases: Usecases
     private lateinit var alarmRepository: AlarmRepository
@@ -56,6 +62,8 @@ class AlarmSystemEndToEndTest {
             alarmRepository = GlobalContext.get().get()
             dateTimeProvider = GlobalContext.get().get<DateTimeProvider>() as DateTimeProviderFake
             dateTimeProvider.clearFixedDateTime()
+            android.os.SystemClock.setCurrentTimeMillis(dateTimeProvider.getCurrentDateTime()
+                .toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds())
         } catch (e: Exception) {
             // If Koin is not initialized, skip these tests
             // In a production setup, ensure TestApplication properly initializes Koin
@@ -64,8 +72,10 @@ class AlarmSystemEndToEndTest {
     }
 
     @Test
-    fun `end-to-end multi-day alarm without repeat - Monday and Wednesday should both ring then stop`() = runBlocking {
+    fun `integration multi-day alarm without repeat - Monday and Wednesday should both ring then stop`() = runTest(testScheduler) {
         dateTimeProvider.setFixedDateTime(LocalDateTime(2026, 4, 19, 6, 0))
+        android.os.SystemClock.setCurrentTimeMillis(dateTimeProvider.getCurrentDateTime()
+            .toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds())
 
         // Create alarm for Monday (index 1) and Wednesday (index 3) at 7:00 AM
         val alarm = Alarm(
@@ -138,7 +148,7 @@ class AlarmSystemEndToEndTest {
     }
     
     @Test
-    fun `end-to-end weekly repeating alarm - schedule, let it ring, verify next week scheduled`() = runBlocking {
+    fun `integration weekly repeating alarm - schedule, let it ring, verify next week scheduled`() = runTest(testScheduler) {
         // Create alarm for only Tuesday with repeat flag (weekly repeat)
         val alarm = Alarm(
             alarmId = 0L,
@@ -178,7 +188,7 @@ class AlarmSystemEndToEndTest {
     }
 
     @Test
-    fun `end-to-end one-time alarm - let it ring, complete, verify turned off`() = runBlocking {
+    fun `integration one-time alarm - let it ring, complete, verify turned off`() = runTest(testScheduler) {
         // Create one-time alarm for tomorrow
         val alarm = Alarm(
             alarmId = 0L,
@@ -228,7 +238,7 @@ class AlarmSystemEndToEndTest {
     }
 
     @Test
-    fun `end-to-end one-time alarm - complete after ring should turn off even before pendingintent cleanup`() = runBlocking {
+    fun `integration one-time alarm - complete after ring should turn off even before pendingintent cleanup`() = runTest(testScheduler) {
         val alarm = Alarm(
             alarmId = 0L,
             hour = 9,
@@ -267,7 +277,7 @@ class AlarmSystemEndToEndTest {
     }
     
     @Test
-    fun `end-to-end weekday alarm - let Monday fire, verify stays on for remaining days`() = runBlocking {
+    fun `integration weekday alarm - let Monday fire, verify stays on for remaining days`() = runTest(testScheduler) {
         // Create weekday alarm (Mon-Fri)
         val alarm = Alarm(
             alarmId = 0L,
@@ -314,7 +324,7 @@ class AlarmSystemEndToEndTest {
     }
     
     @Test
-    fun `end-to-end multiple alarms - let first fire, verify second remains independent`() = runBlocking {
+    fun `integration multiple alarms - let first fire, verify second remains independent`() = runTest(testScheduler) {
         // Create two independent alarms
         val alarm1 = Alarm(
             alarmId = 0L,
@@ -382,7 +392,7 @@ class AlarmSystemEndToEndTest {
     }
     
     @Test
-    fun `end-to-end multi-day weekly repeating alarm - verify multiple weeks continue ringing`() = runBlocking {
+    fun `integration multi-day weekly repeating alarm - verify multiple weeks continue ringing`() = runTest(testScheduler) {
         // Create alarm for Tuesday and Friday with weekly repeat
         val alarm = Alarm(
             alarmId = 0L,
@@ -476,7 +486,7 @@ class AlarmSystemEndToEndTest {
     }
     
     @Test
-    fun `end-to-end boot receiver - system reschedules alarms automatically after reboot`() = runBlocking {
+    fun `integration boot receiver - system reschedules alarms automatically after reboot`() = runTest(testScheduler) {
         // Create and schedule alarm before "reboot"
         val alarm = Alarm(
             alarmId = 0L,
@@ -517,28 +527,18 @@ class AlarmSystemEndToEndTest {
      * This simulates the Android system triggering the alarm at its scheduled time.
      */
     private fun fireNextScheduledAlarm() {
-        val nextAlarm = shadowAlarmManager.nextScheduledAlarm
-        if (nextAlarm != null) {
-            val timeUntilAlarm = nextAlarm.triggerAtTime - ShadowSystemClock.currentTimeMillis()
-            if (timeUntilAlarm > 0) {
-                ShadowSystemClock.advanceBy(timeUntilAlarm, TimeUnit.MILLISECONDS)
-            }
-            val pendingIntent = nextAlarm.operation ?: return
-            val intent = shadowOf(pendingIntent).savedIntent
-            alarmManager.cancel(pendingIntent)
-            pendingIntent.cancel()
-            
-            // Deliver the intent to the broadcast receiver (simulates system behavior)
-            alarmReceiver.onReceive(context, intent)
-        }
+        fireScheduledAlarm(checkNotNull(shadowAlarmManager.nextScheduledAlarm) {
+            "Expected a scheduled occurrence to deliver"
+        })
     }
 
     private fun fireScheduledAlarm(scheduledAlarm: ShadowAlarmManager.ScheduledAlarm) {
+        dateTimeProvider.setFixedDateTime(kotlin.time.Instant.fromEpochMilliseconds(scheduledAlarm.triggerAtTime).toLocalDateTime(TimeZone.currentSystemDefault()))
         val timeUntilAlarm = scheduledAlarm.triggerAtTime - ShadowSystemClock.currentTimeMillis()
         if (timeUntilAlarm > 0) {
             ShadowSystemClock.advanceBy(timeUntilAlarm, TimeUnit.MILLISECONDS)
         }
-        val pendingIntent = scheduledAlarm.operation ?: return
+        val pendingIntent = checkNotNull(scheduledAlarm.operation)
         val intent = shadowOf(pendingIntent).savedIntent
         alarmManager.cancel(pendingIntent)
         pendingIntent.cancel()
@@ -546,11 +546,12 @@ class AlarmSystemEndToEndTest {
     }
 
     private fun fireScheduledAlarmWithoutConsuming(scheduledAlarm: ShadowAlarmManager.ScheduledAlarm) {
+        dateTimeProvider.setFixedDateTime(kotlin.time.Instant.fromEpochMilliseconds(scheduledAlarm.triggerAtTime).toLocalDateTime(TimeZone.currentSystemDefault()))
         val timeUntilAlarm = scheduledAlarm.triggerAtTime - ShadowSystemClock.currentTimeMillis()
         if (timeUntilAlarm > 0) {
             ShadowSystemClock.advanceBy(timeUntilAlarm, TimeUnit.MILLISECONDS)
         }
-        val pendingIntent = scheduledAlarm.operation ?: return
+        val pendingIntent = checkNotNull(scheduledAlarm.operation)
         val intent = shadowOf(pendingIntent).savedIntent
         alarmReceiver.onReceive(context, intent)
     }
@@ -560,7 +561,7 @@ class AlarmSystemEndToEndTest {
      */
     private fun processAsyncOperations() {
         ShadowLooper.idleMainLooper()
-        Thread.sleep(100) // Give coroutines time to complete
+        testScheduler.advanceUntilIdle()
         ShadowLooper.idleMainLooper() // Process any resulting work
     }
 }

--- a/androidApp/src/test/java/com/timilehinaregbesola/mathalarm/AlarmSystemIntegrationTest.kt
+++ b/androidApp/src/test/java/com/timilehinaregbesola/mathalarm/AlarmSystemIntegrationTest.kt
@@ -260,7 +260,7 @@ class AlarmSystemIntegrationTest {
         val nextAlarm = shadowAlarmManager.nextScheduledAlarm!!
         val baseIntent = shadowOf(nextAlarm.operation).savedIntent
 
-        fireScheduledAlarmWithoutConsuming(nextAlarm)
+        fireScheduledAlarm(nextAlarm, consume = false)
         processAsyncOperations()
 
         val completeIntent = Intent(baseIntent).apply {
@@ -532,27 +532,24 @@ class AlarmSystemIntegrationTest {
         })
     }
 
-    private fun fireScheduledAlarm(scheduledAlarm: ShadowAlarmManager.ScheduledAlarm) {
-        dateTimeProvider.setFixedDateTime(kotlin.time.Instant.fromEpochMilliseconds(scheduledAlarm.triggerAtTime).toLocalDateTime(TimeZone.currentSystemDefault()))
+    private fun fireScheduledAlarm(
+        scheduledAlarm: ShadowAlarmManager.ScheduledAlarm,
+        consume: Boolean = true,
+    ) {
+        dateTimeProvider.setFixedDateTime(
+            kotlin.time.Instant.fromEpochMilliseconds(scheduledAlarm.triggerAtTime)
+                .toLocalDateTime(TimeZone.currentSystemDefault())
+        )
         val timeUntilAlarm = scheduledAlarm.triggerAtTime - ShadowSystemClock.currentTimeMillis()
         if (timeUntilAlarm > 0) {
             ShadowSystemClock.advanceBy(timeUntilAlarm, TimeUnit.MILLISECONDS)
         }
         val pendingIntent = checkNotNull(scheduledAlarm.operation)
         val intent = shadowOf(pendingIntent).savedIntent
-        alarmManager.cancel(pendingIntent)
-        pendingIntent.cancel()
-        alarmReceiver.onReceive(context, intent)
-    }
-
-    private fun fireScheduledAlarmWithoutConsuming(scheduledAlarm: ShadowAlarmManager.ScheduledAlarm) {
-        dateTimeProvider.setFixedDateTime(kotlin.time.Instant.fromEpochMilliseconds(scheduledAlarm.triggerAtTime).toLocalDateTime(TimeZone.currentSystemDefault()))
-        val timeUntilAlarm = scheduledAlarm.triggerAtTime - ShadowSystemClock.currentTimeMillis()
-        if (timeUntilAlarm > 0) {
-            ShadowSystemClock.advanceBy(timeUntilAlarm, TimeUnit.MILLISECONDS)
+        if (consume) {
+            alarmManager.cancel(pendingIntent)
+            pendingIntent.cancel()
         }
-        val pendingIntent = checkNotNull(scheduledAlarm.operation)
-        val intent = shadowOf(pendingIntent).savedIntent
         alarmReceiver.onReceive(context, intent)
     }
 

--- a/androidApp/src/test/java/com/timilehinaregbesola/mathalarm/TestApplication.kt
+++ b/androidApp/src/test/java/com/timilehinaregbesola/mathalarm/TestApplication.kt
@@ -5,15 +5,18 @@ import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.ui.ExperimentalComposeUiApi
 import co.touchlab.kermit.Logger
+import com.timilehinaregbesola.mathalarm.coroutines.AppCoroutineScope
 import com.timilehinaregbesola.mathalarm.framework.app.di.appModule
+import com.timilehinaregbesola.mathalarm.framework.database.AlarmDatabase
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.GlobalContext
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 
 /**
  * Test Application class that initializes Koin for Robolectric tests.
- * This allows end-to-end tests to use the real dependency injection setup.
+ * This allows integration tests to use the real dependency injection setup.
  */
 class TestApplication : Application() {
     @OptIn(
@@ -43,8 +46,9 @@ class TestApplication : Application() {
     }
     
     override fun onTerminate() {
-        org.koin.core.context.GlobalContext.get().get<com.timilehinaregbesola.mathalarm.coroutines.AppCoroutineScope>().cancel()
-        org.koin.core.context.GlobalContext.get().get<com.timilehinaregbesola.mathalarm.framework.database.AlarmDatabase>().close()
+        val koin = GlobalContext.get()
+        koin.get<AppCoroutineScope>().cancel()
+        koin.get<AlarmDatabase>().close()
         stopKoin()
         super.onTerminate()
     }

--- a/androidApp/src/test/java/com/timilehinaregbesola/mathalarm/TestApplication.kt
+++ b/androidApp/src/test/java/com/timilehinaregbesola/mathalarm/TestApplication.kt
@@ -43,6 +43,8 @@ class TestApplication : Application() {
     }
     
     override fun onTerminate() {
+        org.koin.core.context.GlobalContext.get().get<com.timilehinaregbesola.mathalarm.coroutines.AppCoroutineScope>().cancel()
+        org.koin.core.context.GlobalContext.get().get<com.timilehinaregbesola.mathalarm.framework.database.AlarmDatabase>().close()
         stopKoin()
         super.onTerminate()
     }

--- a/androidApp/src/test/java/com/timilehinaregbesola/mathalarm/TestOverrides.kt
+++ b/androidApp/src/test/java/com/timilehinaregbesola/mathalarm/TestOverrides.kt
@@ -6,6 +6,7 @@ import com.timilehinaregbesola.mathalarm.fake.DateTimeProviderFake
 import com.timilehinaregbesola.mathalarm.framework.database.AlarmDatabase
 import com.timilehinaregbesola.mathalarm.provider.DateTimeProvider
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
@@ -13,11 +14,11 @@ import org.koin.dsl.module
 val testModule = module {
     single { TestCoroutineScheduler() }
     single { StandardTestDispatcher(get<TestCoroutineScheduler>()) }
-    single { AppCoroutineScope(get<kotlinx.coroutines.test.TestDispatcher>()) }
+    single { AppCoroutineScope(get<TestDispatcher>()) }
     single<DateTimeProvider> { DateTimeProviderFake() }
     single<AlarmDatabase> {
         Room.inMemoryDatabaseBuilder(androidContext(), AlarmDatabase::class.java)
-            .setQueryCoroutineContext(get<kotlinx.coroutines.test.TestDispatcher>())
+            .setQueryCoroutineContext(get<TestDispatcher>())
             .build()
     }
 }

--- a/androidApp/src/test/java/com/timilehinaregbesola/mathalarm/TestOverrides.kt
+++ b/androidApp/src/test/java/com/timilehinaregbesola/mathalarm/TestOverrides.kt
@@ -1,9 +1,23 @@
 package com.timilehinaregbesola.mathalarm
 
+import androidx.room.Room
+import com.timilehinaregbesola.mathalarm.coroutines.AppCoroutineScope
 import com.timilehinaregbesola.mathalarm.fake.DateTimeProviderFake
+import com.timilehinaregbesola.mathalarm.framework.database.AlarmDatabase
 import com.timilehinaregbesola.mathalarm.provider.DateTimeProvider
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 val testModule = module {
+    single { TestCoroutineScheduler() }
+    single { StandardTestDispatcher(get<TestCoroutineScheduler>()) }
+    single { AppCoroutineScope(get<kotlinx.coroutines.test.TestDispatcher>()) }
     single<DateTimeProvider> { DateTimeProviderFake() }
+    single<AlarmDatabase> {
+        Room.inMemoryDatabaseBuilder(androidContext(), AlarmDatabase::class.java)
+            .setQueryCoroutineContext(get<kotlinx.coroutines.test.TestDispatcher>())
+            .build()
+    }
 }

--- a/androidApp/src/test/java/com/timilehinaregbesola/mathalarm/fake/DateTimeProviderFake.kt
+++ b/androidApp/src/test/java/com/timilehinaregbesola/mathalarm/fake/DateTimeProviderFake.kt
@@ -2,21 +2,18 @@ package com.timilehinaregbesola.mathalarm.fake
 
 import com.timilehinaregbesola.mathalarm.provider.DateTimeProvider
 import kotlinx.datetime.LocalDateTime
-import kotlin.time.ExperimentalTime
 
 class DateTimeProviderFake : DateTimeProvider {
-    private var fixedDateTime: LocalDateTime = LocalDateTime(2030, 1, 6, 6, 0)
+    private val baseline = LocalDateTime(2030, 1, 6, 6, 0)
+    private var fixedDateTime = baseline
 
-    @OptIn(ExperimentalTime::class)
-    override fun getCurrentDateTime(): LocalDateTime {
-        return fixedDateTime
-    }
+    override fun getCurrentDateTime(): LocalDateTime = fixedDateTime
 
     fun setFixedDateTime(dateTime: LocalDateTime) {
         fixedDateTime = dateTime
     }
 
     fun clearFixedDateTime() {
-        fixedDateTime = LocalDateTime(2030, 1, 6, 6, 0)
+        fixedDateTime = baseline
     }
 }

--- a/androidApp/src/test/java/com/timilehinaregbesola/mathalarm/fake/DateTimeProviderFake.kt
+++ b/androidApp/src/test/java/com/timilehinaregbesola/mathalarm/fake/DateTimeProviderFake.kt
@@ -2,17 +2,14 @@ package com.timilehinaregbesola.mathalarm.fake
 
 import com.timilehinaregbesola.mathalarm.provider.DateTimeProvider
 import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
-import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 class DateTimeProviderFake : DateTimeProvider {
-    private var fixedDateTime: LocalDateTime? = null
+    private var fixedDateTime: LocalDateTime = LocalDateTime(2030, 1, 6, 6, 0)
 
     @OptIn(ExperimentalTime::class)
     override fun getCurrentDateTime(): LocalDateTime {
-        return fixedDateTime ?: Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+        return fixedDateTime
     }
 
     fun setFixedDateTime(dateTime: LocalDateTime) {
@@ -20,6 +17,6 @@ class DateTimeProviderFake : DateTimeProvider {
     }
 
     fun clearFixedDateTime() {
-        fixedDateTime = null
+        fixedDateTime = LocalDateTime(2030, 1, 6, 6, 0)
     }
 }

--- a/core/src/commonMain/kotlin/com/timilehinaregbesola/mathalarm/coroutines/AppCoroutineScope.kt
+++ b/core/src/commonMain/kotlin/com/timilehinaregbesola/mathalarm/coroutines/AppCoroutineScope.kt
@@ -15,12 +15,14 @@ import kotlin.coroutines.CoroutineContext
  * - Can be properly cancelled if needed during app shutdown
  * 
  */
-class AppCoroutineScope : CoroutineScope {
+class AppCoroutineScope(
+    private val dispatcher: kotlinx.coroutines.CoroutineDispatcher = Dispatchers.Default
+) : CoroutineScope {
     
     private val job = SupervisorJob()
     
     override val coroutineContext: CoroutineContext
-        get() = Dispatchers.Default + job
+        get() = dispatcher + job
 
     /**
      * Launch a coroutine in the application scope.

--- a/core/src/commonMain/kotlin/com/timilehinaregbesola/mathalarm/coroutines/AppCoroutineScope.kt
+++ b/core/src/commonMain/kotlin/com/timilehinaregbesola/mathalarm/coroutines/AppCoroutineScope.kt
@@ -1,5 +1,6 @@
 package com.timilehinaregbesola.mathalarm.coroutines
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -16,7 +17,7 @@ import kotlin.coroutines.CoroutineContext
  * 
  */
 class AppCoroutineScope(
-    private val dispatcher: kotlinx.coroutines.CoroutineDispatcher = Dispatchers.Default
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : CoroutineScope {
     
     private val job = SupervisorJob()

--- a/core/src/commonMain/kotlin/com/timilehinaregbesola/mathalarm/provider/AlarmTimeCalculatorImpl.kt
+++ b/core/src/commonMain/kotlin/com/timilehinaregbesola/mathalarm/provider/AlarmTimeCalculatorImpl.kt
@@ -12,7 +12,8 @@ import kotlin.time.ExperimentalTime
 
 @OptIn(ExperimentalTime::class)
 class AlarmTimeCalculatorImpl(
-    private val dateTimeProvider: DateTimeProvider = DateTimeProviderImpl()
+    private val dateTimeProvider: DateTimeProvider = DateTimeProviderImpl(),
+    private val timeZone: () -> TimeZone = { TimeZone.currentSystemDefault() }
 ) : AlarmTimeCalculator {
 
     companion object {
@@ -21,7 +22,7 @@ class AlarmTimeCalculatorImpl(
     }
 
     override fun calculateAlarmTimes(alarm: Alarm): List<Long> {
-        val tz = TimeZone.currentSystemDefault()
+        val tz = timeZone()
         val localNow = dateTimeProvider.getCurrentDateTime()
         val nowInstant = localNow.toInstant(tz)
         val todayDate = localNow.date
@@ -83,7 +84,7 @@ class AlarmTimeCalculatorImpl(
 
     @OptIn(ExperimentalTime::class)
     override fun isInFuture(timeInMillis: Long): Boolean {
-        val tz = TimeZone.currentSystemDefault()
+        val tz = timeZone()
         val currentTime = dateTimeProvider.getCurrentDateTime().toInstant(tz).toEpochMilliseconds()
         return timeInMillis > currentTime
     }

--- a/core/src/commonMain/kotlin/com/timilehinaregbesola/mathalarm/provider/CalendarProviderImpl.kt
+++ b/core/src/commonMain/kotlin/com/timilehinaregbesola/mathalarm/provider/CalendarProviderImpl.kt
@@ -10,7 +10,10 @@ import kotlin.time.ExperimentalTime
 /**
  * Provide the date and time to be used on the alarm use cases, respecting the Inversion of Control.
  */
-class DateTimeProviderImpl : DateTimeProvider {
+class DateTimeProviderImpl(
+    private val clock: Clock = Clock.System,
+    private val timeZone: () -> TimeZone = { TimeZone.currentSystemDefault() }
+) : DateTimeProvider {
 
     /**
      * Gets the current [LocalDateTime] in the system default time zone.
@@ -19,5 +22,5 @@ class DateTimeProviderImpl : DateTimeProvider {
      */
     @OptIn(ExperimentalTime::class)
     override fun getCurrentDateTime(): LocalDateTime =
-        Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+        clock.now().toLocalDateTime(timeZone())
 }

--- a/core/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/fake/AlarmTimeCalculatorFake.kt
+++ b/core/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/fake/AlarmTimeCalculatorFake.kt
@@ -2,7 +2,6 @@ package com.timilehinaregbesola.mathalarm.fake
 
 import com.timilehinaregbesola.mathalarm.domain.model.Alarm
 import com.timilehinaregbesola.mathalarm.provider.AlarmTimeCalculator
-import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 /**
@@ -11,7 +10,7 @@ import kotlin.time.ExperimentalTime
 @OptIn(ExperimentalTime::class)
 class AlarmTimeCalculatorFake : AlarmTimeCalculator {
     
-    private var currentTimeMillis: Long = Clock.System.now().toEpochMilliseconds()
+    private var currentTimeMillis: Long = 1_893_909_600_000L // 2030-01-06T06:00:00Z
     
     /**
      * Set a custom current time for testing.

--- a/core/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/fake/DateTimeProviderFake.kt
+++ b/core/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/fake/DateTimeProviderFake.kt
@@ -2,15 +2,12 @@ package com.timilehinaregbesola.mathalarm.fake
 
 import com.timilehinaregbesola.mathalarm.provider.DateTimeProvider
 import kotlinx.datetime.LocalDateTime
-import kotlin.time.ExperimentalTime
 
 class DateTimeProviderFake : DateTimeProvider {
-    private var fixedDateTime: LocalDateTime = LocalDateTime(2030, 1, 6, 6, 0)
+    private val baseline = LocalDateTime(2030, 1, 6, 6, 0)
+    private var fixedDateTime = baseline
 
-    @OptIn(ExperimentalTime::class)
-    override fun getCurrentDateTime(): LocalDateTime {
-        return fixedDateTime
-    }
+    override fun getCurrentDateTime(): LocalDateTime = fixedDateTime
 
     /**
      * Set a fixed date/time for deterministic testing.
@@ -37,6 +34,6 @@ class DateTimeProviderFake : DateTimeProvider {
      * Reset to the deterministic Sunday baseline.
      */
     fun clearFixedDateTime() {
-        fixedDateTime = LocalDateTime(2030, 1, 6, 6, 0)
+        fixedDateTime = baseline
     }
 }

--- a/core/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/fake/DateTimeProviderFake.kt
+++ b/core/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/fake/DateTimeProviderFake.kt
@@ -2,17 +2,14 @@ package com.timilehinaregbesola.mathalarm.fake
 
 import com.timilehinaregbesola.mathalarm.provider.DateTimeProvider
 import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
-import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 class DateTimeProviderFake : DateTimeProvider {
-    private var fixedDateTime: LocalDateTime? = null
+    private var fixedDateTime: LocalDateTime = LocalDateTime(2030, 1, 6, 6, 0)
 
     @OptIn(ExperimentalTime::class)
     override fun getCurrentDateTime(): LocalDateTime {
-        return fixedDateTime ?: Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+        return fixedDateTime
     }
 
     /**
@@ -37,9 +34,9 @@ class DateTimeProviderFake : DateTimeProvider {
     }
 
     /**
-     * Clear the fixed time and return to using the real clock.
+     * Reset to the deterministic Sunday baseline.
      */
     fun clearFixedDateTime() {
-        fixedDateTime = null
+        fixedDateTime = LocalDateTime(2030, 1, 6, 6, 0)
     }
 }

--- a/core/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/provider/AlarmCalendarBoundaryTest.kt
+++ b/core/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/provider/AlarmCalendarBoundaryTest.kt
@@ -1,0 +1,49 @@
+package com.timilehinaregbesola.mathalarm.provider
+
+import com.timilehinaregbesola.mathalarm.domain.model.Alarm
+import com.timilehinaregbesola.mathalarm.fake.DateTimeProviderFake
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AlarmCalendarBoundaryTest {
+    private fun next(now: LocalDateTime, zone: String, hour: Int, minute: Int): Long {
+        val clock = DateTimeProviderFake().apply { setFixedDateTime(now) }
+        return AlarmTimeCalculatorImpl(clock) { TimeZone.of(zone) }
+            .calculateNextAlarmTime(Alarm(hour = hour, minute = minute, repeatDays = "TTTTTTT"))!!
+    }
+
+    @Test fun dailyAlarmKeepsLocalTimeAcrossSpringDst() {
+        val zone = TimeZone.of("Europe/London")
+        val now = LocalDateTime(2030, 3, 30, 8, 0)
+        val expected = LocalDateTime(2030, 3, 31, 7, 0).toInstant(zone).toEpochMilliseconds()
+        assertEquals(expected, next(now, zone.id, 7, 0))
+    }
+
+    @Test fun dailyAlarmKeepsLocalTimeAcrossAutumnDst() {
+        val zone = TimeZone.of("Europe/London")
+        val now = LocalDateTime(2030, 10, 26, 8, 0)
+        val expected = LocalDateTime(2030, 10, 27, 7, 0).toInstant(zone).toEpochMilliseconds()
+        assertEquals(expected, next(now, zone.id, 7, 0))
+    }
+
+    @Test fun midnightCrossesYearBoundary() {
+        val expected = LocalDateTime(2031, 1, 1, 0, 0).toInstant(TimeZone.UTC).toEpochMilliseconds()
+        assertEquals(expected, next(LocalDateTime(2030, 12, 31, 23, 59), "UTC", 0, 0))
+    }
+
+    @Test fun everyWeekdayMaskProducesExactlyItsSelectedDays() {
+        val clock = DateTimeProviderFake().apply { setFixedDateTime(2030, 1, 6, 6, 0) }
+        val calculator = AlarmTimeCalculatorImpl(clock) { TimeZone.UTC }
+        for (mask in 1..127) {
+            val days = (0..6).map { if (mask and (1 shl it) != 0) 'T' else 'F' }.joinToString("")
+            val times = calculator.calculateAlarmTimes(Alarm(hour = 7, minute = 0, repeatDays = days))
+            val expected = (0..6).filter { mask and (1 shl it) != 0 }.map {
+                LocalDateTime(2030, 1, 6 + it, 7, 0).toInstant(TimeZone.UTC).toEpochMilliseconds()
+            }
+            assertEquals(expected, times, "weekday mask $days")
+        }
+    }
+}

--- a/core/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/provider/AlarmTimeCalculatorImplTest.kt
+++ b/core/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/provider/AlarmTimeCalculatorImplTest.kt
@@ -21,7 +21,7 @@ class AlarmTimeCalculatorImplTest {
     @BeforeTest
     fun setup() {
         dateTimeProvider = DateTimeProviderFake()
-        calculator = AlarmTimeCalculatorImpl(dateTimeProvider)
+        calculator = AlarmTimeCalculatorImpl(dateTimeProvider) { TimeZone.UTC }
     }
 
     @Test
@@ -217,7 +217,7 @@ class AlarmTimeCalculatorImplTest {
         dateTimeProvider.setFixedDateTime(2025, 1, 8, 10, 0)
         
         val futureTime = LocalDateTime(2025, 1, 8, 11, 0)
-            .toInstant(TimeZone.currentSystemDefault())
+            .toInstant(TimeZone.UTC)
             .toEpochMilliseconds()
         
         calculator.isInFuture(futureTime) shouldBe true
@@ -228,7 +228,7 @@ class AlarmTimeCalculatorImplTest {
         dateTimeProvider.setFixedDateTime(2025, 1, 8, 10, 0)
         
         val pastTime = LocalDateTime(2025, 1, 8, 9, 0)
-            .toInstant(TimeZone.currentSystemDefault())
+            .toInstant(TimeZone.UTC)
             .toEpochMilliseconds()
         
         calculator.isInFuture(pastTime) shouldBe false
@@ -282,6 +282,6 @@ class AlarmTimeCalculatorImplTest {
 
     private fun instantToLocalDateTime(epochMillis: Long): LocalDateTime {
         return Instant.fromEpochMilliseconds(epochMillis)
-            .toLocalDateTime(TimeZone.currentSystemDefault())
+            .toLocalDateTime(TimeZone.UTC)
     }
 }

--- a/core/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/provider/DateTimeProviderTest.kt
+++ b/core/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/provider/DateTimeProviderTest.kt
@@ -1,74 +1,28 @@
 package com.timilehinaregbesola.mathalarm.provider
 
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 class DateTimeProviderTest {
+    private var instant = Instant.parse("2030-12-31T23:59:59Z")
+    private val clock = object : Clock { override fun now() = instant }
 
-    @OptIn(ExperimentalTime::class)
-    @Test
-    fun `getCurrentDateTime should return current time`() {
-        val provider = DateTimeProviderImpl()
-        val beforeCall = Clock.System.now()
-        
-        val dateTime = provider.getCurrentDateTime()
-        dateTime shouldNotBe null
-        
-        val beforeLocal = beforeCall.toLocalDateTime(TimeZone.currentSystemDefault())
-
-        // Year, month, day should match
-        dateTime.year shouldBe beforeLocal.year
-        @Suppress("DEPRECATION")
-        (dateTime.monthNumber == beforeLocal.monthNumber) shouldBe true
-        dateTime.dayOfMonth shouldBe beforeLocal.dayOfMonth
+    @Test fun dateRollsOverAtMidnight() {
+        val provider = DateTimeProviderImpl(clock) { TimeZone.UTC }
+        assertEquals(LocalDateTime(2030, 12, 31, 23, 59, 59), provider.getCurrentDateTime())
+        instant = Instant.parse("2031-01-01T00:00:00Z")
+        assertEquals(LocalDateTime(2031, 1, 1, 0, 0), provider.getCurrentDateTime())
     }
 
-    @OptIn(ExperimentalTime::class)
-    @Test
-    fun `getCurrentDateTime should use system default timezone`() {
-        val provider = DateTimeProviderImpl()
-        
-        val dateTime = provider.getCurrentDateTime()
-        val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
-        
-        dateTime.hour shouldBe now.hour
-        dateTime.minute shouldBe now.minute
-    }
-
-    @OptIn(ExperimentalTime::class)
-    @Test
-    fun `multiple calls should return increasing time`() {
-        val provider = DateTimeProviderImpl()
-        
-        val time1 = provider.getCurrentDateTime()
-        val time2 = provider.getCurrentDateTime()
-        
-        @Suppress("DEPRECATION")
-        val isSameOrLater = time2.year >= time1.year &&
-                           time2.monthNumber >= time1.monthNumber &&
-                           time2.dayOfMonth >= time1.dayOfMonth
-        isSameOrLater shouldBe true
-    }
-
-    @Test
-    fun `getCurrentDateTime should return valid LocalDateTime`() {
-        val provider = DateTimeProviderImpl()
-        
-        val dateTime = provider.getCurrentDateTime()
-
-        with(dateTime) {
-            (year in 2024..2100) shouldBe true // Reasonable range
-            @Suppress("DEPRECATION")
-            (monthNumber in 1..12) shouldBe true
-            (dayOfMonth in 1..31) shouldBe true
-            (hour in 0..23) shouldBe true
-            (minute in 0..59) shouldBe true
-            (second in 0..59) shouldBe true
-        }
+    @Test fun readsTheCurrentZoneOnEveryCall() {
+        var zone: TimeZone = TimeZone.UTC
+        val provider = DateTimeProviderImpl(clock) { zone }
+        assertEquals(LocalDateTime(2030, 12, 31, 23, 59, 59), provider.getCurrentDateTime())
+        zone = TimeZone.of("Asia/Tokyo")
+        assertEquals(LocalDateTime(2031, 1, 1, 8, 59, 59), provider.getCurrentDateTime())
     }
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,134 @@
+# Testing Math Alarm
+
+## Fast checks (every PR)
+
+```sh
+./gradlew :core:testAndroidHostTest :shared:testAndroidHostTest :androidApp:testDebugUnitTest --continue
+```
+
+The domain and ViewModel suites cover recurrence, persisted occurrences, editing,
+undo, failure propagation, snoozing, and command ordering. Calendar tests enumerate
+all 127 nonempty weekday masks and exercise DST/year boundaries. A regression fix
+must include an assertion about the final persisted state **and** the scheduled
+occurrences, rather than merely verifying that a method was called.
+
+`AlarmSystemIntegrationTest` runs real use cases, Room and Android adapters in
+Robolectric. It manually delivers broadcasts; it is not a device end-to-end test.
+Its Room query context and application scope share a `TestCoroutineScheduler`.
+Use `runTest`, `runCurrent` or `advanceUntilIdle` to finish the work being asserted.
+Do not add sleeps or retry a failed assertion until it turns green. Close databases
+and cancel scopes at teardown.
+
+Fake clocks default to Sunday 2030-01-06 06:00, never today's date. Set explicit dates
+for date-sensitive cases. Pure calendar tests inject a timezone; production timezone
+providers remain dynamic so travel/system-zone changes are still observed. Tests
+that exercise system-zone adapters intentionally use the same zone for inputs and
+expected instants. CI runs host suites with `TZ=UTC`.
+
+Android host tests fail on unimplemented framework calls instead of silently
+returning null/zero. Use Robolectric for Android behavior and explicit fakes for
+application boundaries.
+
+## Real Android delivery
+
+Build/install the debug app and test APKs on a disposable emulator:
+
+```sh
+./gradlew :androidApp:assembleDebug :androidApp:assembleDebugAndroidTest
+adb -s emulator-5554 install -r androidApp/build/outputs/apk/debug/androidApp-debug.apk
+adb -s emulator-5554 install -r androidApp/build/outputs/apk/androidTest/debug/androidApp-debug-androidTest.apk
+python3 scripts/test_alarm_delivery.py --serial emulator-5554 --scenario cold-start
+```
+
+Pass `--adb /path/to/adb` when platform-tools is not on PATH. Use a separate
+`--output build/alarm-device-results/SCENARIO` for each run.
+
+| Scenario | What the runner verifies |
+| --- | --- |
+| `cold-start` | Future alarm registration, process exit, locked screen, real OS broadcast, service and player start, completion persisted |
+| `snooze` | Cold-start path, snooze command stops the first alarm, a distinct real occurrence rings about a minute later, completion clears it |
+| `doze` | Confirm deep idle before waiting for the OS delivery path |
+| `reboot` | Seed an occurrence five minutes ahead, actually reboot, unlock credential storage, observe delivery without reopening the app |
+
+The runner exits instrumentation **before** killing the process or rebooting.
+It never injects the alarm-fire broadcast. It sends the production snooze/complete
+commands to exercise those receiver paths; button navigation and solving math are
+covered separately by the physical-device checklist. `am kill` is intentional:
+Android force-stop suppresses scheduled background work until the user launches
+the app again and is a different product scenario.
+
+The fixture uses alarm ID 900001, a missing custom sound URI to exercise fallback,
+and a one-minute snooze. It cleans up that alarm after each run. It resets the test
+app's delivery log and grants required permissions on the disposable emulator.
+The Doze fixture temporarily sets `min_time_to_alarm=0` to allow a near-future
+alarm into deep idle, then restores the original setting. Android normally avoids
+deep idle shortly before alarm-clock events. This accelerated fixture complements
+the overnight physical-device check.
+Do not use an emulator containing alarms you need to preserve. A failed run is
+not retried automatically. Polling is bounded and waits for observable state;
+it does not assume an operation finished after a fixed sleep.
+
+Artifacts include event timestamps, alarm-manager state, audio state, logcat,
+instrumentation results and a machine-readable result. `audio_started` proves
+that the playback path reached `MediaPlayer.start`; it does **not** measure acoustic
+output. `result.json` records audibility as **not measured**.
+
+## CI
+
+Every PR, including a PR targeting `codex/**`, runs host suites and API 35
+cold-start/snooze checks. Scheduled and manually dispatched runs additionally
+exercise APIs 30, 32, 36, Doze, reboot and native iOS simulator suites. Reports are
+uploaded even on failure. GitHub only starts the nightly schedule once this workflow
+is on the default branch; use workflow dispatch for earlier broad validation.
+
+```sh
+./gradlew :core:iosSimulatorArm64Test :shared:iosSimulatorArm64Test --continue
+```
+
+Native tests verify the shared rules and iOS adapter contract. They do not establish
+that AlarmKit notifications are audible on a physical iPhone.
+
+## Physical-device release checks
+
+Run on a Pixel/reference Android device and at least one supported manufacturer
+with different battery restrictions. Include the affected customer model when
+known. Repeat the relevant checks on a physical iPhone before an iOS release.
+Record app commit/version, OS/device, timezone, battery restriction mode, alarm
+volume, DND, notification/full-screen permissions, selected tone and observed times.
+
+1. Create a future alarm through the UI; leave the app, lock the screen and wait.
+   Confirm sound is audible from the intended speaker, vibration follows settings,
+   and the notification opens the math screen.
+2. Enter a wrong answer: audio continues. Solve the required questions: sound stops,
+   the screen closes, and the persisted enabled/disabled state matches recurrence.
+3. Snooze through the UI: sound stops promptly and returns at the displayed snooze
+   time. Solve it after the second delivery. Confirm the next recurring alarm remains.
+4. Repeat after a real reboot and first unlock, and after prolonged screen-off/Doze.
+   Separately document behavior before first unlock; the current database requires
+   credential storage, so post-unlock success is not proof of pre-unlock delivery.
+5. Test a removed/inaccessible custom tone and confirm an audible fallback. Check
+   alarm-stream volume, DND, Bluetooth routing and silent-mode behavior individually.
+   Record muted/unrouted sound as a failed audibility check even if telemetry says
+   playback started. Use an external microphone/recording with timestamps when
+   reproducible acoustic evidence is needed.
+6. Schedule two close alarms. Complete the first and verify the second still rings.
+   Disable/delete a snoozed alarm and verify it never rings again. Edit a time and
+   verify the old occurrence does not ring. Undo deletion and verify real delivery.
+7. Change timezone/time, update the app, and change exact-alarm/notification settings.
+   Verify scheduled times and visible errors agree with what the OS actually accepts.
+8. Leave a repeating alarm overnight for several days. Record every expected and
+   observed occurrence; the in-app preview is not an overnight reliability check.
+
+Use this record for each case:
+
+| Case | Expected time | Receiver time | Audio event | Audible? | UI/state result | Pass/fail + evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| | | | | | | |
+
+## Stacking this change
+
+`codex/reliable-alarm-tests` starts at `codex/fix-alarm-reliability`. Open its PR
+against that branch so reviewers see only the testing changes. After the parent
+merges, retarget to `main`. If the parent was squash-merged, rebase the testing
+commits onto `main` using the old parent tip as the boundary before retargeting;
+otherwise the old reliability commits may appear again in the diff.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,6 +4,7 @@
 
 ```sh
 ./gradlew :core:testAndroidHostTest :shared:testAndroidHostTest :androidApp:testDebugUnitTest --continue
+python3 -B -m unittest discover -s scripts -p '*_test.py'
 ```
 
 The domain and ViewModel suites cover recurrence, persisted occurrences, editing,
@@ -60,8 +61,9 @@ the app again and is a different product scenario.
 The fixture uses alarm ID 900001, a missing custom sound URI to exercise fallback,
 and a one-minute snooze. It cleans up that alarm after each run. It resets the test
 app's delivery log and grants required permissions on the disposable emulator.
-The Doze fixture temporarily sets `min_time_to_alarm=0` to allow a near-future
-alarm into deep idle, then restores the original setting. Android normally avoids
+The Doze fixture schedules three minutes ahead and temporarily sets
+`min_time_to_alarm=0,idle_to=30000`. This permits a confirmed 30-second initial idle
+window outside Android’s early-wake margin, then restores the original settings. Android normally avoids
 deep idle shortly before alarm-clock events. This accelerated fixture complements
 the overnight physical-device check.
 Do not use an emulator containing alarms you need to preserve. A failed run is

--- a/scripts/alarm_delivery_runner_test.py
+++ b/scripts/alarm_delivery_runner_test.py
@@ -1,0 +1,29 @@
+"""Failure-path checks for emulator state restoration; no device required."""
+import unittest
+
+from test_alarm_delivery import run_cleanup
+
+
+class CleanupTest(unittest.TestCase):
+    def test_failures_do_not_skip_settings_or_alarm_cleanup(self):
+        completed = []
+
+        def fail():
+            raise RuntimeError("device command failed")
+
+        errors = run_cleanup([
+            ("exit idle", fail),
+            ("reset battery", fail),
+            ("restore idle settings", lambda: completed.append("settings")),
+            ("remove test alarm", lambda: completed.append("alarm")),
+        ])
+
+        self.assertEqual(["settings", "alarm"], completed)
+        self.assertEqual({"exit idle": "device command failed", "reset battery": "device command failed"}, errors)
+
+    def test_successful_cleanup_reports_no_errors(self):
+        self.assertEqual({}, run_cleanup([("cleanup", lambda: None)]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci_alarm_delivery.sh
+++ b/scripts/ci_alarm_delivery.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+serial=emulator-5554
+adb -s "$serial" install -r androidApp/build/outputs/apk/debug/androidApp-debug.apk
+adb -s "$serial" install -r androidApp/build/outputs/apk/androidTest/debug/androidApp-debug-androidTest.apk
+scenarios=(cold-start snooze)
+if [[ "${EXTENDED:-false}" == true ]]; then
+  scenarios+=(doze reboot)
+fi
+status=0
+for scenario in "${scenarios[@]}"; do
+  python3 scripts/test_alarm_delivery.py --serial "$serial" --scenario "$scenario" \
+    --output "build/alarm-device-results/$scenario" || status=1
+done
+exit "$status"

--- a/scripts/test_alarm_delivery.py
+++ b/scripts/test_alarm_delivery.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Real OS delivery checks. Requires installed debug + test APKs and an explicit emulator serial.
+
+Instrumentation exits before process death / Doze / reboot. This runner never injects ALARM_ACTION.
+Player-start telemetry proves the playback path ran, not acoustic audibility.
+"""
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+import subprocess
+import time
+import xml.etree.ElementTree as ET
+
+PACKAGE = "com.timilehinaregbesola.mathalarm.debug"
+TEST_CLASS = "com.timilehinaregbesola.mathalarm.AlarmDeliverySeedTest"
+RECEIVER = "com.timilehinaregbesola.mathalarm.AlarmReceiver"
+ALARM_ID = 900001
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--serial", required=True)
+    parser.add_argument("--scenario", choices=["cold-start", "doze", "reboot", "snooze"], default="cold-start")
+    parser.add_argument("--output", type=Path, default=Path("build/alarm-device-results"))
+    parser.add_argument("--adb", default=os.environ.get("ADB", "adb"))
+    args = parser.parse_args()
+    if not args.serial.startswith("emulator-"):
+        parser.error("Automated reboot/Doze tests require a disposable emulator; use the physical-device checklist for phones")
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    def adb(*command, check=True, timeout=30):
+        result = subprocess.run([args.adb, "-s", args.serial, *command], capture_output=True, text=True, timeout=timeout)
+        if check and result.returncode:
+            raise RuntimeError(f"adb {command}: {result.stderr or result.stdout}")
+        return result.stdout
+
+    def instrument(method, delay=45):
+        output = adb("shell", "am", "instrument", "-w", "-r", "-e", "alarmLifecycle", "true",
+                     "-e", "delaySeconds", str(delay), "-e", "class", f"{TEST_CLASS}#{method}",
+                     f"{PACKAGE}.test/androidx.test.runner.AndroidJUnitRunner", timeout=90)
+        (args.output / f"{method}.txt").write_text(output)
+        if "OK (1 test)" not in output or "FAILURES" in output:
+            raise AssertionError(output)
+
+    def events():
+        raw = adb("shell", "run-as", PACKAGE, "cat", "shared_prefs/alarm_delivery_log.xml")
+        return [e for e in json.loads(ET.fromstring(raw).find("string[@name='events']").text)
+                if e["alarmId"] == ALARM_ID]
+
+    def wait_for(description, predicate, timeout):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate():
+                return
+            time.sleep(0.5)  # Bounded polling of real device state, never a completion guess.
+        raise AssertionError(f"Timed out: {description}")
+
+    def delivered(count):
+        log = events()
+        if any(e["event"] in ("audio_failed", "schedule_failed") for e in log):
+            raise AssertionError(json.dumps(log, indent=2))
+        for name in ("received", "service_started", "audio_started"):
+            if sum(e["event"] == name for e in log) < count:
+                return False
+        return True
+
+    def command(action):
+        adb("shell", "am", "broadcast", "-n", f"{PACKAGE}/{RECEIVER}", "-a",
+            f"com.timilehinaregbesola.mathalarm.{action}", "--el", "extra_task", str(ALARM_ID))
+
+    result = {"scenario": args.scenario, "serial": args.serial, "audibility": "not measured"}
+    seeded = False
+    idle_constants = None
+    try:
+        api = int(adb("shell", "getprop", "ro.build.version.sdk").strip())
+        if api >= 33:
+            adb("shell", "pm", "grant", PACKAGE, "android.permission.POST_NOTIFICATIONS")
+        if 31 <= api <= 32:
+            adb("shell", "appops", "set", PACKAGE, "SCHEDULE_EXACT_ALARM", "allow")
+        seeded = True
+        instrument("seedColdStartAlarm", 300 if args.scenario == "reboot" else 45)
+        print(f"{args.scenario}: alarm registered", flush=True)
+        initial = next(e for e in events() if e["event"] == "scheduled")
+        trigger = initial["triggerAt"]
+        adb("shell", "input", "keyevent", "KEYCODE_HOME")
+        adb("shell", "input", "keyevent", "KEYCODE_SLEEP")
+        # am kill allows normal scheduled wakeups; force-stop would intentionally suppress them.
+        adb("shell", "am", "kill", PACKAGE)
+        wait_for("app process exited", lambda: not adb("shell", "pidof", PACKAGE, check=False).strip(), 15)
+        print(f"{args.scenario}: app process exited", flush=True)
+        if args.scenario == "doze":
+            # Android normally avoids Doze for an alarm-clock event within one hour.
+            # Shorten only this test timing guard, then restore its original value.
+            idle_constants = adb("shell", "settings", "get", "global", "device_idle_constants").strip()
+            constants = [] if idle_constants in ("", "null") else idle_constants.split(",")
+            constants = [c for c in constants if not c.startswith("min_time_to_alarm=")]
+            adb("shell", "settings", "put", "global", "device_idle_constants",
+                ",".join(constants + ["min_time_to_alarm=0"]))
+            wait_for("test idle threshold applied", lambda: "min_time_to_alarm=0" in
+                     adb("shell", "dumpsys", "deviceidle"), 10)
+            adb("shell", "dumpsys", "battery", "unplug")
+            idle_output = adb("shell", "dumpsys", "deviceidle", "force-idle", "deep")
+            state = adb("shell", "dumpsys", "deviceidle", "get", "deep").strip()
+            (args.output / "idle-entry.txt").write_text(idle_output + "\nstate=" + state)
+            assert state == "IDLE", f"Could not enter deep idle: {idle_output}; state={state}"
+        if args.scenario == "reboot":
+            old_boot = adb("shell", "cat", "/proc/sys/kernel/random/boot_id").strip()
+            adb("reboot")
+            def new_boot_completed():
+                boot_id = adb("shell", "cat", "/proc/sys/kernel/random/boot_id", check=False).strip()
+                return bool(boot_id and boot_id != old_boot) and adb(
+                    "shell", "getprop", "sys.boot_completed", check=False).strip() == "1"
+            wait_for("new boot completed", new_boot_completed, 240)
+            print("reboot: new boot completed", flush=True)
+            adb("shell", "input", "keyevent", "KEYCODE_WAKEUP")
+            adb("shell", "wm", "dismiss-keyguard")
+            adb("shell", "input", "keyevent", "KEYCODE_SLEEP")
+        wait_for("OS receiver, service and player start", lambda: delivered(1), 330 if args.scenario == "reboot" else 90)
+        print(f"{args.scenario}: receiver, service and player observed", flush=True)
+        log = events()
+        received = next(e for e in log if e["event"] == "received")
+        assert received["triggerAt"] == trigger, log
+        assert received["at"] >= trigger - 1000, "Alarm arrived before its scheduled occurrence"
+        if args.scenario == "reboot":
+            assert sum(e["event"] == "scheduled" for e in log) >= 2, "Boot recovery did not re-register the alarm"
+        if args.scenario == "snooze":
+            command("SNOOZE")
+            wait_for("snooze stops current playback", lambda: any(e["event"] == "dismissed" for e in events()), 15)
+            wait_for("real snooze delivery", lambda: delivered(2), 90)
+            triggers = [e["triggerAt"] for e in events() if e["event"] == "received"]
+            assert len(set(triggers)) == 2, triggers
+        command("SET_COMPLETE")
+        expected_dismissals = 2 if args.scenario == "snooze" else 1
+        wait_for("completion", lambda: sum(e["event"] == "dismissed" for e in events()) >= expected_dismissals, 15)
+        wait_for("alarm service stopped", lambda: not re.search(
+            r"ServiceRecord[^\n]*AlarmService", adb("shell", "dumpsys", "activity", "services", PACKAGE)), 15)
+        # Re-enter instrumentation only after the background journey has completed.
+        instrument("verifyCompleted")
+        result["status"] = "passed"
+    except Exception as error:
+        result.update(status="failed", error=str(error))
+    finally:
+        for name, command_args in {
+            "alarm.txt": ("shell", "dumpsys", "alarm"),
+            "audio.txt": ("shell", "dumpsys", "audio"),
+            "deviceidle.txt": ("shell", "dumpsys", "deviceidle"),
+            "logcat.txt": ("logcat", "-d", "-t", "2000"),
+        }.items():
+            try:
+                (args.output / name).write_text(adb(*command_args, check=False))
+            except Exception:
+                pass
+        try:
+            (args.output / "events.json").write_text(json.dumps(events(), indent=2))
+        except Exception:
+            pass
+        try:
+            if args.scenario == "doze":
+                adb("shell", "dumpsys", "deviceidle", "unforce")
+                adb("shell", "dumpsys", "battery", "reset")
+                if idle_constants is not None:
+                    if idle_constants in ("", "null"):
+                        adb("shell", "settings", "delete", "global", "device_idle_constants")
+                    else:
+                        adb("shell", "settings", "put", "global", "device_idle_constants", idle_constants)
+            if seeded:
+                instrument("cleanup")
+        except Exception as error:
+            result.update(status="failed", cleanup_error=str(error))
+        (args.output / "result.json").write_text(json.dumps(result, indent=2))
+        print(json.dumps(result, indent=2))
+    if result["status"] != "passed":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_alarm_delivery.py
+++ b/scripts/test_alarm_delivery.py
@@ -19,6 +19,17 @@ RECEIVER = "com.timilehinaregbesola.mathalarm.AlarmReceiver"
 ALARM_ID = 900001
 
 
+def run_cleanup(steps):
+    """Attempt every restoration step, preserving all failures for the run report."""
+    errors = {}
+    for name, operation in steps:
+        try:
+            operation()
+        except Exception as error:
+            errors[name] = str(error)
+    return errors
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--serial", required=True)
@@ -80,7 +91,8 @@ def main():
         if 31 <= api <= 32:
             adb("shell", "appops", "set", PACKAGE, "SCHEDULE_EXACT_ALARM", "allow")
         seeded = True
-        instrument("seedColdStartAlarm", 300 if args.scenario == "reboot" else 45)
+        lead_seconds = {"reboot": 300, "doze": 180}.get(args.scenario, 45)
+        instrument("seedColdStartAlarm", lead_seconds)
         print(f"{args.scenario}: alarm registered", flush=True)
         initial = next(e for e in events() if e["event"] == "scheduled")
         trigger = initial["triggerAt"]
@@ -92,19 +104,22 @@ def main():
         print(f"{args.scenario}: app process exited", flush=True)
         if args.scenario == "doze":
             # Android normally avoids Doze for an alarm-clock event within one hour.
-            # Shorten only this test timing guard, then restore its original value.
+            # Use a 30-second initial idle window with the alarm three minutes away,
+            # outside AlarmManager's two-minute early-wake margin. Restore both settings.
             idle_constants = adb("shell", "settings", "get", "global", "device_idle_constants").strip()
             constants = [] if idle_constants in ("", "null") else idle_constants.split(",")
-            constants = [c for c in constants if not c.startswith("min_time_to_alarm=")]
+            constants = [c for c in constants if not c.startswith(("min_time_to_alarm=", "idle_to="))]
             adb("shell", "settings", "put", "global", "device_idle_constants",
-                ",".join(constants + ["min_time_to_alarm=0"]))
+                ",".join(constants + ["min_time_to_alarm=0", "idle_to=30000"]))
             wait_for("test idle threshold applied", lambda: "min_time_to_alarm=0" in
                      adb("shell", "dumpsys", "deviceidle"), 10)
             adb("shell", "dumpsys", "battery", "unplug")
             idle_output = adb("shell", "dumpsys", "deviceidle", "force-idle", "deep")
-            state = adb("shell", "dumpsys", "deviceidle", "get", "deep").strip()
-            (args.output / "idle-entry.txt").write_text(idle_output + "\nstate=" + state)
-            assert state == "IDLE", f"Could not enter deep idle: {idle_output}; state={state}"
+            def is_deep_idle():
+                state = adb("shell", "dumpsys", "deviceidle", "get", "deep").strip()
+                (args.output / "idle-entry.txt").write_text(idle_output + "\nstate=" + state)
+                return state == "IDLE"
+            wait_for("confirmed deep idle after any maintenance window", is_deep_idle, 15)
         if args.scenario == "reboot":
             old_boot = adb("shell", "cat", "/proc/sys/kernel/random/boot_id").strip()
             adb("reboot")
@@ -117,7 +132,7 @@ def main():
             adb("shell", "input", "keyevent", "KEYCODE_WAKEUP")
             adb("shell", "wm", "dismiss-keyguard")
             adb("shell", "input", "keyevent", "KEYCODE_SLEEP")
-        wait_for("OS receiver, service and player start", lambda: delivered(1), 330 if args.scenario == "reboot" else 90)
+        wait_for("OS receiver, service and player start", lambda: delivered(1), lead_seconds + 45)
         print(f"{args.scenario}: receiver, service and player observed", flush=True)
         log = events()
         received = next(e for e in log if e["event"] == "received")
@@ -156,19 +171,21 @@ def main():
             (args.output / "events.json").write_text(json.dumps(events(), indent=2))
         except Exception:
             pass
-        try:
-            if args.scenario == "doze":
-                adb("shell", "dumpsys", "deviceidle", "unforce")
-                adb("shell", "dumpsys", "battery", "reset")
-                if idle_constants is not None:
-                    if idle_constants in ("", "null"):
-                        adb("shell", "settings", "delete", "global", "device_idle_constants")
-                    else:
-                        adb("shell", "settings", "put", "global", "device_idle_constants", idle_constants)
-            if seeded:
-                instrument("cleanup")
-        except Exception as error:
-            result.update(status="failed", cleanup_error=str(error))
+        cleanup_steps = []
+        if args.scenario == "doze":
+            cleanup_steps.extend([
+                ("exit idle", lambda: adb("shell", "dumpsys", "deviceidle", "unforce")),
+                ("reset battery", lambda: adb("shell", "dumpsys", "battery", "reset")),
+            ])
+            if idle_constants is not None:
+                restore = ("delete", "global", "device_idle_constants") if idle_constants in ("", "null") else (
+                    "put", "global", "device_idle_constants", idle_constants)
+                cleanup_steps.append(("restore idle settings", lambda: adb("shell", "settings", *restore)))
+        if seeded:
+            cleanup_steps.append(("remove test alarm", lambda: instrument("cleanup")))
+        cleanup_errors = run_cleanup(cleanup_steps)
+        if cleanup_errors:
+            result.update(status="failed", cleanup_errors=cleanup_errors)
         (args.output / "result.json").write_text(json.dumps(result, indent=2))
         print(json.dumps(result, indent=2))
     if result["status"] != "passed":

--- a/shared/src/commonMain/kotlin/com/timilehinaregbesola/mathalarm/utils/AlarmUtil.kt
+++ b/shared/src/commonMain/kotlin/com/timilehinaregbesola/mathalarm/utils/AlarmUtil.kt
@@ -63,9 +63,12 @@ fun DayOfWeek.toIndex(): Int = when (this) {
  * Like getTodayDateTimeInSystemZone(), but enforces second=0.
  */
 @OptIn(ExperimentalTime::class)
-fun Alarm.initLocalDateTimeInSystemZone(): LocalDateTime {
-    val nowInstant = Clock.System.now()
-    val tz = TimeZone.currentSystemDefault()
+fun Alarm.initLocalDateTimeInSystemZone(
+    clock: Clock = Clock.System,
+    timeZone: TimeZone = TimeZone.currentSystemDefault()
+): LocalDateTime {
+    val nowInstant = clock.now()
+    val tz = timeZone
     val today = nowInstant.toLocalDateTime(tz).date
     return LocalDateTime(
         date = today,
@@ -81,8 +84,8 @@ fun Alarm.initLocalDateTimeInSystemZone(): LocalDateTime {
  * @return The next time the alarm will go off as an Instant, or null if the alarm has no repeat days set
  */
 @OptIn(ExperimentalTime::class)
-fun calculateNextAlarmTime(alarm: Alarm, timeZone: TimeZone = TimeZone.currentSystemDefault()): Instant? {
-    val nowInstant = Clock.System.now()
+fun calculateNextAlarmTime(alarm: Alarm, timeZone: TimeZone = TimeZone.currentSystemDefault(), clock: Clock = Clock.System): Instant? {
+    val nowInstant = clock.now()
     val localNow = nowInstant.toLocalDateTime(timeZone)
     val todayDate = localNow.date
 

--- a/shared/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/fake/AlarmTimeCalculatorFake.kt
+++ b/shared/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/fake/AlarmTimeCalculatorFake.kt
@@ -2,7 +2,6 @@ package com.timilehinaregbesola.mathalarm.fake
 
 import com.timilehinaregbesola.mathalarm.domain.model.Alarm
 import com.timilehinaregbesola.mathalarm.provider.AlarmTimeCalculator
-import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 /**
@@ -11,7 +10,7 @@ import kotlin.time.ExperimentalTime
 @OptIn(ExperimentalTime::class)
 class AlarmTimeCalculatorFake : AlarmTimeCalculator {
     
-    private var currentTimeMillis: Long = Clock.System.now().toEpochMilliseconds()
+    private var currentTimeMillis: Long = 1_893_909_600_000L // 2030-01-06T06:00:00Z
     
     /**
      * Set a custom current time for testing.

--- a/shared/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/fake/DateTimeProviderFake.kt
+++ b/shared/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/fake/DateTimeProviderFake.kt
@@ -2,21 +2,18 @@ package com.timilehinaregbesola.mathalarm.fake
 
 import com.timilehinaregbesola.mathalarm.provider.DateTimeProvider
 import kotlinx.datetime.LocalDateTime
-import kotlin.time.ExperimentalTime
 
 class DateTimeProviderFake : DateTimeProvider {
-    private var fixedDateTime: LocalDateTime = LocalDateTime(2030, 1, 6, 6, 0)
+    private val baseline = LocalDateTime(2030, 1, 6, 6, 0)
+    private var fixedDateTime = baseline
 
-    @OptIn(ExperimentalTime::class)
-    override fun getCurrentDateTime(): LocalDateTime {
-        return fixedDateTime
-    }
+    override fun getCurrentDateTime(): LocalDateTime = fixedDateTime
 
     fun setFixedDateTime(dateTime: LocalDateTime) {
         fixedDateTime = dateTime
     }
 
     fun clearFixedDateTime() {
-        fixedDateTime = LocalDateTime(2030, 1, 6, 6, 0)
+        fixedDateTime = baseline
     }
 }

--- a/shared/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/fake/DateTimeProviderFake.kt
+++ b/shared/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/fake/DateTimeProviderFake.kt
@@ -2,17 +2,14 @@ package com.timilehinaregbesola.mathalarm.fake
 
 import com.timilehinaregbesola.mathalarm.provider.DateTimeProvider
 import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
-import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 class DateTimeProviderFake : DateTimeProvider {
-    private var fixedDateTime: LocalDateTime? = null
+    private var fixedDateTime: LocalDateTime = LocalDateTime(2030, 1, 6, 6, 0)
 
     @OptIn(ExperimentalTime::class)
     override fun getCurrentDateTime(): LocalDateTime {
-        return fixedDateTime ?: Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+        return fixedDateTime
     }
 
     fun setFixedDateTime(dateTime: LocalDateTime) {
@@ -20,6 +17,6 @@ class DateTimeProviderFake : DateTimeProvider {
     }
 
     fun clearFixedDateTime() {
-        fixedDateTime = null
+        fixedDateTime = LocalDateTime(2030, 1, 6, 6, 0)
     }
 }

--- a/shared/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/presentation/alarmlist/AlarmListViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/presentation/alarmlist/AlarmListViewModelTest.kt
@@ -85,6 +85,32 @@ class AlarmListViewModelTest {
     }
 
     @Test
+    fun `undo preserves disabled status and does not schedule`() = runTest {
+        val alarm = Alarm(alarmId = 800, hour = 7, minute = 0, isSaved = true, isOn = false)
+        usecases.addAlarm(alarm)
+        viewModel.onEvent(AlarmListEvent.OnDeleteAlarmClick(alarm))
+        advanceUntilIdle()
+        viewModel.onEvent(AlarmListEvent.OnUndoDeleteClick)
+        advanceUntilIdle()
+        usecases.findAlarm(800)!!.isOn shouldBe false
+        alarmInteractor.isAlarmScheduled(alarm) shouldBe false
+    }
+
+    @Test
+    fun `rapid enable disable enable leaves one current schedule`() = runTest {
+        val alarm = Alarm(alarmId = 801, hour = 7, minute = 0, isSaved = true)
+        usecases.addAlarm(alarm)
+        viewModel.onEvent(AlarmListEvent.OnAlarmOnChange(alarm, true))
+        viewModel.onEvent(AlarmListEvent.OnAlarmOnChange(alarm, false))
+        viewModel.onEvent(AlarmListEvent.OnAlarmOnChange(alarm, true))
+        advanceUntilIdle()
+        val stored = usecases.findAlarm(801)!!
+        stored.isOn shouldBe true
+        stored.scheduleError shouldBe null
+        listOf(alarmInteractor.getScheduledAlarms()[801]!!.timeInMillis) shouldBe stored.pendingTimes
+    }
+
+    @Test
     fun `initial state should have empty alarm list`() = runTest {
         val alarms = viewModel.alarms.first()
         alarms shouldBe emptyList()

--- a/shared/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/utils/AlarmUtilTest.kt
+++ b/shared/src/commonTest/kotlin/com/timilehinaregbesola/mathalarm/utils/AlarmUtilTest.kt
@@ -11,6 +11,9 @@ import kotlinx.datetime.toLocalDateTime
 import kotlin.test.Test
 
 class AlarmUtilTest {
+    private val clock = object : kotlin.time.Clock {
+        override fun now() = kotlin.time.Instant.parse("2030-01-06T23:59:59Z")
+    }
 
     @Test
     fun `getFormatTime should format midnight correctly`() {
@@ -75,7 +78,7 @@ class AlarmUtilTest {
     fun `initLocalDateTimeInSystemZone should create LocalDateTime with alarm time`() {
         val alarm = Alarm(hour = 10, minute = 30)
         
-        val dateTime = alarm.initLocalDateTimeInSystemZone()
+        val dateTime = alarm.initLocalDateTimeInSystemZone(clock, TimeZone.UTC)
         dateTime.hour shouldBe 10
         dateTime.minute shouldBe 30
         dateTime.second shouldBe 0
@@ -89,7 +92,7 @@ class AlarmUtilTest {
             repeatDays = "FFFFFFF" // No repeat days
         )
         
-        val nextTime = calculateNextAlarmTime(alarm)
+        val nextTime = calculateNextAlarmTime(alarm, TimeZone.UTC, clock)
         nextTime shouldNotBe null
     }
 
@@ -101,7 +104,7 @@ class AlarmUtilTest {
             repeatDays = "TTTTTTT"
         )
         
-        val nextTime = calculateNextAlarmTime(alarm)
+        val nextTime = calculateNextAlarmTime(alarm, TimeZone.UTC, clock)
         nextTime shouldNotBe null
     }
 
@@ -113,7 +116,7 @@ class AlarmUtilTest {
             repeatDays = "FTFTFTT"
         )
         
-        val nextTime = calculateNextAlarmTime(alarm)
+        val nextTime = calculateNextAlarmTime(alarm, TimeZone.UTC, clock)
         nextTime shouldNotBe null
     }
 
@@ -220,9 +223,9 @@ class AlarmUtilTest {
             minute = 0,
             repeatDays = "TTTTTTT"
         )
-        val timeZone = TimeZone.currentSystemDefault()
+        val timeZone = TimeZone.UTC
         
-        val nextTime = calculateNextAlarmTime(alarm, timeZone)
+        val nextTime = calculateNextAlarmTime(alarm, timeZone, clock)
         nextTime shouldNotBe null
     }
 
@@ -230,9 +233,9 @@ class AlarmUtilTest {
     fun `initLocalDateTimeInSystemZone should use current date`() {
         val alarm = Alarm(hour = 14, minute = 30)
         
-        val dateTime = alarm.initLocalDateTimeInSystemZone()
-        val now = kotlin.time.Clock.System.now()
-            .toLocalDateTime(TimeZone.currentSystemDefault())
+        val dateTime = alarm.initLocalDateTimeInSystemZone(clock, TimeZone.UTC)
+        val now = clock.now()
+            .toLocalDateTime(TimeZone.UTC)
         
         dateTime.date shouldBe now.date
         dateTime.hour shouldBe 14


### PR DESCRIPTION
Alarm tests currently depend on real-clock defaults and fixed sleeps, while the Robolectric suite cannot verify Android waking the app and starting playback. This change makes host tests deterministic and adds real emulator checks for cold-start delivery, snooze, Doze, and reboot recovery.

- Inject clocks, timezones and coroutine dispatchers; share a test scheduler between the receiver and Room, consolidate delivery helpers, and fail on unstubbed Android calls.
- Add weekday-mask, DST, year-boundary, disabled-undo and rapid-toggle regression coverage.
- Add an external device runner that exits instrumentation before process death/reboot, observes receiver/service/player events, verifies completion state, and saves diagnostics. Cleanup attempts every restoration step even if an earlier step fails.
- Run host and API 35 smoke checks on PRs; expand Android and iOS coverage on scheduled/manual runs. Document physical-device audibility and math-screen release checks.

Validation:
- 258 host tests passed; 2 runner cleanup tests passed.
- 188 iOS simulator tests passed during implementation.
- API 35 cold-start, snooze, Doze and reboot scenarios passed. The final cleanup pass reran host tests and the revised Doze fixture successfully.
- Workflow YAML and shell syntax checked; hosted CI has not yet been verified.

The device runner checks playback events, not acoustic audibility, and sends production snooze/completion commands rather than exercising the math UI. Physical speaker output and UI interactions remain documented release checks. The Doze fixture temporarily adjusts idle timings and restores the original settings.

Builds on the alarm reliability fixes merged in #64. This PR now targets main and contains only the testing changes.
